### PR TITLE
[Bugfix] Drop __constructor with required parameters on models

### DIFF
--- a/src/EventListener/NotFoundListener.php
+++ b/src/EventListener/NotFoundListener.php
@@ -19,7 +19,7 @@ abstract class NotFoundListener
 
         $exception = $event->getThrowable();
 
-        if (!$exception instanceof HttpException || 404 !== (int) $exception->getStatusCode()) {
+        if (!$exception instanceof HttpException || 404 !== $exception->getStatusCode()) {
             return false;
         }
 

--- a/src/Form/Type/RedirectType.php
+++ b/src/Form/Type/RedirectType.php
@@ -48,7 +48,7 @@ class RedirectType extends AbstractType
             'data_class' => $this->class,
             'disable_source' => false,
             'empty_data' => function(FormInterface $form) use ($class) {
-                return new $class(
+                return $class::create(
                     $form->get('source')->getData(),
                     $form->get('destination')->getData()
                 );

--- a/src/Model/NotFound.php
+++ b/src/Model/NotFound.php
@@ -7,9 +7,9 @@ namespace Zenstruck\RedirectBundle\Model;
  */
 abstract class NotFound
 {
-    protected string $path;
+    protected ?string $path = null;
 
-    protected string $fullUrl;
+    protected ?string $fullUrl = null;
 
     protected ?\DateTime $timestamp;
 
@@ -49,22 +49,22 @@ abstract class NotFound
         return $this->path;
     }
 
-    public function setPath(string $path): void
+    public function setPath(?string $path): void
     {
         $this->path = $path;
     }
 
-    public function getFullUrl(): string
+    public function getFullUrl(): ?string
     {
         return $this->fullUrl;
     }
 
-    public function setFullUrl(string $fullUrl): void
+    public function setFullUrl(?string $fullUrl): void
     {
         $this->fullUrl = $fullUrl;
     }
 
-    public function getTimestamp(): \DateTime
+    public function getTimestamp(): ?\DateTime
     {
         return $this->timestamp;
     }

--- a/src/Model/NotFound.php
+++ b/src/Model/NotFound.php
@@ -9,12 +9,16 @@ abstract class NotFound
 {
     protected string $path;
 
+    protected string $fullUrl;
+
     protected ?\DateTime $timestamp;
 
     protected ?string $referer;
 
-    public function __construct(string $path, protected string $fullUrl, ?string $referer = null, ?\DateTime $timestamp = null)
+    public static function create(string $path, string $fullUrl, ?string $referer = null, ?\DateTime $timestamp = null): static
     {
+        $notFound = new static();
+
         if (null === $timestamp) {
             $timestamp = new \DateTime('now');
         }
@@ -32,9 +36,12 @@ abstract class NotFound
             }
         }
 
-        $this->path = $path;
-        $this->referer = $referer;
-        $this->timestamp = $timestamp;
+        $notFound->setPath($path);
+        $notFound->setFullUrl($fullUrl);
+        $notFound->setReferer($referer);
+        $notFound->setTimestamp($timestamp);
+
+        return $notFound;
     }
 
     public function getPath(): ?string
@@ -42,9 +49,19 @@ abstract class NotFound
         return $this->path;
     }
 
+    public function setPath(string $path): void
+    {
+        $this->path = $path;
+    }
+
     public function getFullUrl(): string
     {
         return $this->fullUrl;
+    }
+
+    public function setFullUrl(string $fullUrl): void
+    {
+        $this->fullUrl = $fullUrl;
     }
 
     public function getTimestamp(): \DateTime
@@ -52,8 +69,18 @@ abstract class NotFound
         return $this->timestamp;
     }
 
+    public function setTimestamp(?\DateTime $timestamp): void
+    {
+        $this->timestamp = $timestamp;
+    }
+
     public function getReferer(): ?string
     {
         return $this->referer;
+    }
+
+    public function setReferer(?string $referer): void
+    {
+        $this->referer = $referer;
     }
 }

--- a/src/Model/Redirect.php
+++ b/src/Model/Redirect.php
@@ -17,16 +17,20 @@ abstract class Redirect
 
     protected ?\DateTime $lastAccessed = null;
 
-    public function __construct(string $source, string $destination, bool $permanent = true)
+    public static function create(string $source, string $destination, bool $permanent = true): static
     {
-        $this->setSource($source);
-        $this->setDestination($destination);
-        $this->setPermanent($permanent);
+        $redirect = new static();
+
+        $redirect->setSource($source);
+        $redirect->setDestination($destination);
+        $redirect->setPermanent($permanent);
+
+        return $redirect;
     }
 
     public static function createFromNotFound(NotFound $notFound, string $destination, bool $permanent = true): static
     {
-        return new static($notFound->getPath(), $destination, $permanent);
+        return self::create($notFound->getPath(), $destination, $permanent);
     }
 
     public function getSource(): string

--- a/src/Model/Redirect.php
+++ b/src/Model/Redirect.php
@@ -7,11 +7,11 @@ namespace Zenstruck\RedirectBundle\Model;
  */
 abstract class Redirect
 {
-    protected string $source;
+    protected ?string $source = null;
 
-    protected string $destination;
+    protected ?string $destination = null;
 
-    protected bool $permanent;
+    protected bool $permanent = true;
 
     protected int $count = 0;
 
@@ -33,12 +33,12 @@ abstract class Redirect
         return self::create($notFound->getPath(), $destination, $permanent);
     }
 
-    public function getSource(): string
+    public function getSource(): ?string
     {
         return $this->source;
     }
 
-    public function setSource(string $source): void
+    public function setSource(?string $source): void
     {
         $source = \trim($source);
         $source = !empty($source) ? $source : null;
@@ -50,12 +50,12 @@ abstract class Redirect
         $this->source = $source;
     }
 
-    public function getDestination(): string
+    public function getDestination(): ?string
     {
         return $this->destination;
     }
 
-    public function setDestination(string $destination): void
+    public function setDestination(?string $destination): void
     {
         $destination = \trim($destination);
         $destination = !empty($destination) ? $destination : null;

--- a/src/Service/NotFoundManager.php
+++ b/src/Service/NotFoundManager.php
@@ -21,7 +21,7 @@ class NotFoundManager
 
     public function createFromRequest(Request $request): NotFound
     {
-        $notFound = new $this->class(
+        $notFound = $this->class::create(
             $request->getPathInfo(),
             $request->getUri(),
             $request->server->get('HTTP_REFERER')

--- a/tests/EventListener/RedirectOnNotFoundListenerTest.php
+++ b/tests/EventListener/RedirectOnNotFoundListenerTest.php
@@ -31,7 +31,7 @@ class RedirectOnNotFoundListenerTest extends NotFoundListenerTest
         $this->redirectManager->expects($this->once())
             ->method('findAndUpdate')
             ->with('/foo/bar')
-            ->willReturn(new DummyRedirect('/foo/bar', '/baz'))
+            ->willReturn(DummyRedirect::create('/foo/bar', '/baz'))
         ;
 
         $event = $this->createEvent(new NotFoundHttpException(), Request::create('/foo/bar'));

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -74,8 +74,8 @@ abstract class FunctionalTest extends WebTestCase
             ->execute()
         ;
 
-        $this->em->persist(new DummyRedirect('/301-redirect', 'http://symfony.com'));
-        $this->em->persist(new DummyRedirect('/302-redirect', 'http://example.com', false));
+        $this->em->persist(DummyRedirect::create('/301-redirect', 'http://symfony.com'));
+        $this->em->persist(DummyRedirect::create('/302-redirect', 'http://example.com', false));
 
         $this->em->flush();
     }

--- a/tests/Functional/RemoveNotFoundSubscriberTest.php
+++ b/tests/Functional/RemoveNotFoundSubscriberTest.php
@@ -14,9 +14,9 @@ class RemoveNotFoundSubscriberTest extends FunctionalTest
     {
         parent::addTestData();
 
-        $this->em->persist(new DummyNotFound('/foo', 'http://example.com/foo'));
-        $this->em->persist(new DummyNotFound('/foo', 'http://example.com/foo?bar=foo'));
-        $this->em->persist(new DummyNotFound('/bar', 'http://example.com/bar'));
+        $this->em->persist(DummyNotFound::create('/foo', 'http://example.com/foo'));
+        $this->em->persist(DummyNotFound::create('/foo', 'http://example.com/foo?bar=foo'));
+        $this->em->persist(DummyNotFound::create('/bar', 'http://example.com/bar'));
 
         $this->em->flush();
     }
@@ -28,7 +28,7 @@ class RemoveNotFoundSubscriberTest extends FunctionalTest
     {
         $this->assertCount(3, $this->getNotFounds());
 
-        $this->em->persist(new DummyRedirect('/foo', '/bar'));
+        $this->em->persist(DummyRedirect::create('/foo', '/bar'));
         $this->em->flush();
 
         $this->assertCount(1, $this->getNotFounds());

--- a/tests/Functional/ValidationTest.php
+++ b/tests/Functional/ValidationTest.php
@@ -18,9 +18,9 @@ class ValidationTest extends FunctionalTest
         /** @var RecursiveValidator $validator */
         $validator = self::getContainer()->get('validator');
 
-        $this->assertCount(0, $validator->validate(new DummyRedirect('/foo', '/bar')));
+        $this->assertCount(0, $validator->validate(DummyRedirect::create('/foo', '/bar')));
 
-        $errors = $validator->validate(new DummyRedirect('/301-redirect', '/foo'));
+        $errors = $validator->validate(DummyRedirect::create('/301-redirect', '/foo'));
         $this->assertCount(1, $errors);
         $this->assertSame('The source is already used.', $errors[0]->getMessage());
         $this->assertSame('source', $errors[0]->getPropertyPath());

--- a/tests/Model/NotFoundTest.php
+++ b/tests/Model/NotFoundTest.php
@@ -45,9 +45,8 @@ class NotFoundTest extends TestCase
 
     private function createNotFound(string $path, string $fullUrl, ?string $referer = null, ?\DateTime $timestamp = null): \Zenstruck\RedirectBundle\Model\NotFound
     {
-        return $this->getMockForAbstractClass(
-            'Zenstruck\RedirectBundle\Model\NotFound',
-            [$path, $fullUrl, $referer, $timestamp]
-        );
+        $mock = $this->getMockForAbstractClass('Zenstruck\RedirectBundle\Model\NotFound');
+
+        return $mock::create($path, $fullUrl, $referer, $timestamp);
     }
 }

--- a/tests/Model/RedirectTest.php
+++ b/tests/Model/RedirectTest.php
@@ -69,7 +69,7 @@ class RedirectTest extends TestCase
      */
     public function create_from_not_found()
     {
-        $redirect = DummyRedirect::createFromNotFound(new DummyNotFound('/foo', 'https://example.com/foo'), '/baz');
+        $redirect = DummyRedirect::createFromNotFound(DummyNotFound::create('/foo', 'https://example.com/foo'), '/baz');
 
         $this->assertSame('/foo', $redirect->getSource());
     }
@@ -105,9 +105,8 @@ class RedirectTest extends TestCase
 
     private function createRedirect(string $source, string $destination, bool $permanent = true): \Zenstruck\RedirectBundle\Model\Redirect
     {
-        return $this->getMockForAbstractClass(
-            'Zenstruck\RedirectBundle\Model\Redirect',
-            [$source, $destination, $permanent]
-        );
+        $mock = $this->getMockForAbstractClass('Zenstruck\RedirectBundle\Model\Redirect');
+
+        return $mock::create($source, $destination, $permanent);
     }
 }


### PR DESCRIPTION
Hi @kbond 

Trying to use the latest version of bundle with PHP8 support we got some bugs =) And this PR should fix all of them I hope.

The main issue was that trying to create an empty object with the form on the project I got a TypeError that I can't assign `null` to a property defined as `string`. It's really legit so I looked closer in the code and found that if I create an `Redirect` with empty string `''` data, then `setSource()` method converts empty string to `null` and then it fails because `$source` property is defined as non-nullable... and so on

Also, I got some issues with EasyAdmin because EA instantiates entity with an empty constructor, so I decided to improve this part of the code, and move constructor logic to static `create` methods.

Cheers!